### PR TITLE
limit the number of allocate and gc jobs to keep around in history

### DIFF
--- a/jjb-tmpl/cciskel-duffy.yml
+++ b/jjb-tmpl/cciskel-duffy.yml
@@ -86,6 +86,9 @@
       - ansicolor
       - workspace-cleanup
       - timestamps
+    properties:
+        - build-discarder:
+            num-to-keep: 10
 
 # This singleton job ensures that it's the only thing accessing
 # the cached duffy state.


### PR DESCRIPTION
Some jobs in ci.c.o run quite frequently, and there shouldn't be a need to keep
a whole lot of the allocate or gc jobs around. 

Limiting the number of these builds is the motivation for this:
https://ci.centos.org/job/atomic-duffy-allocate/
